### PR TITLE
Handling bleed edge cases and incorrect status indicators

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -8642,12 +8642,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Spike Armor",
 		shortDesc: "30% chance to bleed on contact.",
 		onDamagingHit(damage, target, source, move) {
-			if (!this.dex.getImmunity("bleed", source)) return;
+			if (!this.dex.getImmunity("bld", source)) return;
 			if (move.flags["contact"] == null) return;
 			// if (!this.randomChance(3, 10)) return;
-			if (source.status == "bleed") return;
+			if (source.status == "bld") return;
 			this.add("-activate", target, "ability: Spike Armor");
-			source.trySetStatus('bleed', target, this.dex.abilities.get("spikearmor"));
+			source.trySetStatus('bld', target, this.dex.abilities.get("spikearmor"));
 		}
 	}
 };

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -8644,7 +8644,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onDamagingHit(damage, target, source, move) {
 			if (!this.dex.getImmunity("bleed", source)) return;
 			if (move.flags["contact"] == null) return;
-			if (!this.randomChance(3, 10)) return;
+			// if (!this.randomChance(3, 10)) return;
 			if (source.status == "bleed") return;
 			this.add("-activate", target, "ability: Spike Armor");
 			source.trySetStatus('bleed', target, this.dex.abilities.get("spikearmor"));

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -8612,13 +8612,13 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			 * Handle type immunities to bleed (rock and ghost as of v2.1).
 			 * Weirdly, this function call returns true if the type is NOT immune, despite it's name.
 			 */
-			if (!this.dex.getImmunity("bleed", source)) return;
+			if (!this.dex.getImmunity("bld", source)) return;
 			if (move.category != "Special") return;
 			/**
 			 * This check prevents additional ability activation messages and failure messages 
 			 * from trying to activate bleed on a pokemon who is already bleeding.
 			 */
-			if (source.status == "bleed") return;
+			if (source.status == "bld") return;
 			/**
 			 * This ability has a 30% chance to activate, here we short circuit if that random chance fails.
 			 */

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -8615,14 +8615,14 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (!this.dex.getImmunity("bleed", source)) return;
 			if (move.category != "Special") return;
 			/**
-			 * This ability has a 30% chance to activate, here we short circuit if that random chance fails.
-			 */
-			if (!this.randomChance(3, 10)) return;
-			/**
 			 * This check prevents additional ability activation messages and failure messages 
 			 * from trying to activate bleed on a pokemon who is already bleeding.
 			 */
 			if (source.status == "bleed") return;
+			/**
+			 * This ability has a 30% chance to activate, here we short circuit if that random chance fails.
+			 */
+			if (!this.randomChance(3, 10)) return;
 			/**
 			 * Popup an ability activation message before we bleed the move's source,
 			 * which indicates why the user bleed.

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -71,9 +71,9 @@ export const Conditions: {[k: string]: ConditionData} = {
 		 */
 		onStart(target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.effectType == "Ability") {
-				this.add("-status", target, "bleed", `[from] ability: ${sourceEffect.name}`, ` [of] ${source}`);
+				this.add("-status", target, "bld", `[from] ability: ${sourceEffect.name}`, ` [of] ${source}`);
 			} else if (sourceEffect && sourceEffect.effectType === 'Move') {
-				this.add('-status', target, 'bleed', '[from] move: ' + sourceEffect.name);
+				this.add('-status', target, 'bld', '[from] move: ' + sourceEffect.name);
 			}
 		},
 		/**

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -112,7 +112,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 				delete boost[i];
 			}
 
-			this.add('-fail', target, 'unboost', '[from] status: bleed', '[of] ' + target);
+			this.add('-fail', target, 'boost', '[from] status: bleed', '[of] ' + target);
 		},
 		/** 
 		 * This is (believed) to be used as an order in which status/item/weather residual effects resolve at the end of the battle.

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -60,8 +60,8 @@ export const Conditions: {[k: string]: ConditionData} = {
 	 * - frontend/src/battle-animations.ts:updateStatBar():line 2727, where the status bar is rendered/updated on the client during battle.
 	 * - frontend/style/client.css:line 2070, where the status bar indicators are styled with colors in css.
 	 */
-	bleed: {
-		name: "bleed",
+	bld: {
+		name: "bld",
 		effectType: "Status",
 		/**
 		 * This is called when the status starts and is responsible for populating status activation messages on screen.

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -82,14 +82,14 @@ export const Conditions: {[k: string]: ConditionData} = {
 		 * If so, we block the heal but cure the bleed.
 		 * NOTE: This should cover non-self healing moves i.e. enemy or partner healing moves used on the bleeding pokemon 
 		 */
-		onBeforeMove(source, target, move) {
-			if (move.flags['heal'] && move.category == "Status") {
-				/// Outright block status healing moves.
-				this.add('cant', target, 'status: bleed', move);
-				target.cureStatus();
-				return false;
-			}
-		},
+		// onBeforeMove(source, target, move) {
+		// 	if (move.flags['heal'] && move.category == "Status") {
+		// 		/// Outright block status healing moves.
+		// 		this.add('cant', target, 'status: bleed', move);
+		// 		target.cureStatus();
+		// 		return false;
+		// 	}
+		// },
 		/**
 		 * This is called right before a pokemon is healed by any source.
 		 * In this case, we just prevent the healing.
@@ -98,8 +98,14 @@ export const Conditions: {[k: string]: ConditionData} = {
 		 * The expected behavior is more nuanced.
 		 * It's possible that some conditional messages may be desired here, but more work is needed to iron out all those details.
 		 */
-		onTryHeal(damage, pokemon, source, effect) {
-			return false;
+		onTryHeal(damage, target, source, effect) {
+			if (effect.effectType != "Move") return 0;
+
+			const move = effect as Move;
+			if (move.category != "Status") return 0;
+
+			target.cureStatus();
+			return 0;
 		},
 		/**
 		 * This is called right before the statused target receives any kind of stat boosts. 

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -98,14 +98,20 @@ export const Conditions: {[k: string]: ConditionData} = {
 		 * The expected behavior is more nuanced.
 		 * It's possible that some conditional messages may be desired here, but more work is needed to iron out all those details.
 		 */
-		onTryHeal(damage, target, source, effect) {
-			if (effect.effectType != "Move") return 0;
+		onTryHeal(amount, target, source, effect) {
+			if (effect.effectType == "Condition" && effect.id == "wish") {
+				this.add("-message", `${target.name}'s wish cured it's bleed!`);
+				target.cureStatus(true);
+			}
 
-			const move = effect as Move;
-			if (move.category != "Status") return 0;
+			if (effect.effectType == "Move") {
+				const move = effect as Move;
 
-			target.cureStatus();
-			return 0;
+				if (move.basePower < 0) target.cureStatus();
+				if (move.category == "Status") target.cureStatus();
+			}
+			
+			return this.chainModify(0);
 		},
 		/**
 		 * This is called right before the statused target receives any kind of stat boosts. 

--- a/data/text/default.ts
+++ b/data/text/default.ts
@@ -186,7 +186,7 @@ export const DefaultText: {[k: string]: DefaultText} = {
 	/**
 	 * These are the battle text messages that describe the bleeding status conditions effects/events.
 	 */ 
-	bleed: {
+	bld: {
 		start: "  [POKEMON] started bleeding!",
 		alreadyStarted: "  [POKEMON] is already bleeding!",
 		end: "  [POKEMON] was cured of its bleed!",

--- a/data/typechart.ts
+++ b/data/typechart.ts
@@ -196,7 +196,7 @@ export const TypeChart: {[k: string]: TypeData} = {
 			/**
 			 * Ghosts are immune to bleed, which equates to a 3.
 			 */
-			bleed: 3,
+			bld: 3,
 			trapped: 3,
 			Bug: 2,
 			Dark: 1,
@@ -373,7 +373,7 @@ export const TypeChart: {[k: string]: TypeData} = {
 			/**
 			 * Ghosts are immune to bleed, which equates to a 3.
 			 */
-			bleed: 3,
+			bld: 3,
 			sandstorm: 3,
 			Bug: 0,
 			Dark: 0,

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,18 @@
+{
+  "watch": ["data/", "sim/", "server/"],
+  "ext": "js,ts,css,html,json,tsx,jsx",
+  "verbose": true,
+  "ignore": [
+    ".git",
+    "node_modules/**/node_modules",
+    "js/lib/**",
+    "js/server/**",
+    "js/battle*.js",
+    "js/client-co*.js",
+    "js/client-main.js",
+    "js/client-main.js.map",
+    "js/panel*.js",
+    "js/replay-embed.js",
+    "config/config.js"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/parser": "^5.8.0",
         "eslint": "^8.5.0",
         "mocha": "^8.2.0",
+        "nodemon": "^3.1.4",
         "smogon": "^2.2.1",
         "typescript": "^5.0.4"
       },
@@ -1575,6 +1576,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "devOptional": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -1844,6 +1859,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
     "node_modules/ignore-walk": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
@@ -2102,18 +2123,6 @@
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -2553,6 +2562,103 @@
       "optional": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
+      "integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/nodemon/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/nopt": {
@@ -3043,6 +3149,12 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3304,13 +3416,10 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "devOptional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3403,6 +3512,18 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/slash": {
@@ -3751,6 +3872,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -3842,6 +3972,12 @@
       "engines": {
         "node": ">=12.20"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4016,12 +4152,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "start": "node pokemon-showdown start",
+    "start": "nodemon ./pokemon-showdown start",
     "build": "node build",
     "tsc": "tsc",
     "fast-lint": "eslint . --config .eslintrc-no-types.json --cache --cache-location .eslintcache-no-types --ext .js,.ts,.tsx",
@@ -80,6 +80,7 @@
     "@typescript-eslint/parser": "^5.8.0",
     "eslint": "^8.5.0",
     "mocha": "^8.2.0",
+    "nodemon": "^3.1.4",
     "smogon": "^2.2.1",
     "typescript": "^5.0.4"
   }

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -106,6 +106,10 @@ export interface EventMethods {
 	) => boolean | null | void;
 	onTryEatItem?: boolean | ((this: Battle, item: Item, pokemon: Pokemon) => boolean | void);
 	/* FIXME: onTryHeal() is run with two different sets of arguments */
+	/**
+	 * This is called just before a pokemon is about to be healed by any source.
+	 * Can return a modified amount of healing, false to "fail" the healing, or void to not modify the healing.
+	 */
 	onTryHeal?: (
 		((this: Battle, relayVar: number, target: Pokemon, source: Pokemon, effect: Effect) => number | boolean | void) |
 		((this: Battle, pokemon: Pokemon) => boolean | void) | boolean


### PR DESCRIPTION
Needed to handle all the healing moves within onTryHeal instead of preventing the move entirely. The following edge cases were handled and tested:
- Regenerator + Natural Cure
- Wish (cures bleed on 2nd turn)
- Any status move or healing move that has 0 base power (pollen puff was tested)
- Healing Wish
- Synthesis
- Soft-boiled
- Heal Pulse
- Jungle Healing